### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/common.py
+++ b/common.py
@@ -56,7 +56,7 @@ def popen(exe, cmd, cwd, env=None, decode=True, errors=True, encoding=None):
         debug('> ' + ' '.join(map(f, cmd)))
     pipe = Popen(cmd, cwd=cwd, stdout=PIPE, stderr=PIPE, env=env)
     (stdout, stderr) = pipe.communicate()
-    if encoding == None:
+    if encoding is None:
         encoding = ENCODING
     if errors and pipe.returncode > 0:
         raise Exception(decodeString(encoding, stderr + stdout))

--- a/rebase.py
+++ b/rebase.py
@@ -175,7 +175,7 @@ class Group:
             return str(user).split(' <')[0]
         def getUserEmail(user):
             email = search('<.*@.*>', str(user))
-            if email == None:
+            if email is None:
                 return '<%s@%s>' % (user.lower().replace(' ','.').replace("'", ''), mailSuffix)
             else:
                 return email.group(0)
@@ -194,7 +194,7 @@ class Group:
         try:
             git_exec(['commit', '-m', comment.encode(ENCODING)], env=env)
         except Exception as e:
-            if search('nothing( added)? to commit', e.args[0]) == None:
+            if search('nothing( added)? to commit', e.args[0]) is None:
                 raise
 
 def cc_file(file, version):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:git-cc?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:git-cc?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
