### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/checkin.py
+++ b/checkin.py
@@ -50,7 +50,7 @@ def main(force=False, no_deliver=False, initial=False, all=False, cclabel=''):
         reset.main('HEAD')
 
 def getStatuses(id, initial):
-    cmd = ['diff','--name-status', '-M', '-z', '--ignore-submodules', '%s^..%s' % (id, id)]
+    cmd = ['diff','--name-status', '-M', '-z', '--ignore-submodules', '{0!s}^..{1!s}'.format(id, id)]
     if initial:
         cmd = cmd[:-1]
         cmd[0] = 'show'
@@ -130,6 +130,6 @@ class Transaction(ITransaction):
         gitid = getBlob(self.base, file)
         if ccid != gitid:
             if not IGNORE_CONFLICTS:
-                raise Exception('File has been modified: %s. Try rebasing.' % file)
+                raise Exception('File has been modified: {0!s}. Try rebasing.'.format(file))
             else:
                 print ('WARNING: Detected possible confilct with',file,'...ignoring...')

--- a/common.py
+++ b/common.py
@@ -52,7 +52,7 @@ def cc_exec(cmd, **args):
 def popen(exe, cmd, cwd, env=None, decode=True, errors=True, encoding=None):
     cmd.insert(0, exe)
     if DEBUG:
-        f = lambda a: a if not a.count(' ') else '"%s"' % a
+        f = lambda a: a if not a.count(' ') else '"{0!s}"'.format(a)
         debug('> ' + ' '.join(map(f, cmd)))
     pipe = Popen(cmd, cwd=cwd, stdout=PIPE, stderr=PIPE, env=env)
     (stdout, stderr) = pipe.communicate()
@@ -147,11 +147,11 @@ def removeFile(file):
 
 def validateCC():
     if not CC_DIR:
-        fail("No 'clearcase' variable found for branch '%s'" % CURRENT_BRANCH)
+        fail("No 'clearcase' variable found for branch '{0!s}'".format(CURRENT_BRANCH))
         
 def path(path, args='-m'):
     if IS_CYGWIN:
-        return os.popen('cygpath %s "%s"' %(args, path)).readlines()[0].strip()
+        return os.popen('cygpath {0!s} "{1!s}"'.format(args, path)).readlines()[0].strip()
     else:
         return path
 

--- a/rebase.py
+++ b/rebase.py
@@ -74,7 +74,7 @@ def doCommit(cs):
 
 def getSince():
     try:
-        date = git_exec(['log', '-n', '1', '--pretty=format:%ai', '%s' % CC_TAG])
+        date = git_exec(['log', '-n', '1', '--pretty=format:%ai', '{0!s}'.format(CC_TAG)])
         date = date[:19]
         date = datetime.strptime(date, '%Y-%m-%d %H:%M:%S')
         date = date + timedelta(seconds=1)
@@ -150,9 +150,9 @@ def commit(list):
 
 def printGroups(groups):
     for cs in groups:
-        print('%s "%s"' % (cs.user, cs.subject))
+        print('{0!s} "{1!s}"'.format(cs.user, cs.subject))
         for file in cs.files:
-            print("  %s" % file.file)
+            print("  {0!s}".format(file.file))
 
 class Group:
     def __init__(self, cs):
@@ -176,7 +176,7 @@ class Group:
         def getUserEmail(user):
             email = search('<.*@.*>', str(user))
             if email == None:
-                return '<%s@%s>' % (user.lower().replace(' ','.').replace("'", ''), mailSuffix)
+                return '<{0!s}@{1!s}>'.format(user.lower().replace(' ','.').replace("'", ''), mailSuffix)
             else:
                 return email.group(0)
         files = []
@@ -198,7 +198,7 @@ class Group:
                 raise
 
 def cc_file(file, version):
-    return '%s@@%s' % (file, version)
+    return '{0!s}@@{1!s}'.format(file, version)
 
 class Changeset(object):
     def __init__(self, split, comment):
@@ -223,7 +223,7 @@ class Changeset(object):
         except:
             if len(file) < 200:
                 raise
-            debug("Ignoring %s as it may be related to https://github.com/charleso/git-cc/issues/9" % file)
+            debug("Ignoring {0!s} as it may be related to https://github.com/charleso/git-cc/issues/9".format(file))
         if not exists(toFile):
             git_exec(['checkout', 'HEAD', toFile])
         else:
@@ -259,7 +259,7 @@ class Uncataloged(Changeset):
 
                 versions = self.checkin_versions(actual_versions)
                 if not versions:
-                    print("It appears that you may be missing a branch in the includes section of your gitcc config for file '%s'." % added)
+                    print("It appears that you may be missing a branch in the includes section of your gitcc config for file '{0!s}'.".format(added))
                     continue
                 self._add(added, versions[0][2].strip())
 

--- a/sync.py
+++ b/sync.py
@@ -27,7 +27,7 @@ def main(cache=False):
 
 def copy(file):
     newFile = join(GIT_DIR, file)
-    debug('Copying %s' % newFile)
+    debug('Copying {0!s}'.format(newFile))
     mkdirs(newFile)
     shutil.copy(join(CC_DIR, file), newFile)
     os.chmod(newFile, stat.S_IREAD | stat.S_IWRITE)

--- a/tests/test-checkin.py
+++ b/tests/test-checkin.py
@@ -11,16 +11,16 @@ class CheckinTest(TestCaseEx):
         self.commits = []
     def checkin(self):
         self.expectedExec.insert(1,
-            (['git', 'log', '--first-parent', '--reverse', '--pretty=format:%H%n%s%n%b', '%s..' % CI_TAG], '\n'.join(self.commits)),
+            (['git', 'log', '--first-parent', '--reverse', '--pretty=format:%H%n%s%n%b', '{0!s}..'.format(CI_TAG)], '\n'.join(self.commits)),
         )
         checkin.main()
         self.assert_(not len(self.expectedExec))
     def commit(self, commit, message, files):
         nameStatus = []
         for type, file in files:
-            nameStatus.append('%s\0%s' % (type, file))
+            nameStatus.append('{0!s}\0{1!s}'.format(type, file))
         self.expectedExec.extend([
-            (['git', 'diff', '--name-status', '-M', '-z', '%s^..%s' % (commit, commit)], '\n'.join(nameStatus)),
+            (['git', 'diff', '--name-status', '-M', '-z', '{0!s}^..{1!s}'.format(commit, commit)], '\n'.join(nameStatus)),
         ])
         types = {'M': MockModfy, 'A': MockAdd, 'D': MockDelete, 'R': MockRename}
         self.expectedExec.extend([
@@ -53,7 +53,7 @@ class CheckinTest(TestCaseEx):
 
 class MockStatus:
     def lsTree(self, id, file, hash):
-        return (['git', 'ls-tree', '-z', id, file], '100644 blob %s %s' % (hash, file))
+        return (['git', 'ls-tree', '-z', id, file], '100644 blob {0!s} {1!s}'.format(hash, file))
     def catFile(self, file, hash):
         blob = "blob"
         return [


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:git-cc?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:git-cc?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
